### PR TITLE
fixed for use Google AppEngine

### DIFF
--- a/dadata.go
+++ b/dadata.go
@@ -25,11 +25,21 @@ Create new client of DaData.
 
 Api and secret keys see on profile page (https://dadata.ru/profile/).
 */
-func NewDaData(apiKey, sercretKey string) *DaData {
+func NewDaData(apiKey, secretKey string) *DaData {
+	return NewDaDataCustomClient(apiKey, secretKey, &http.Client{})
+}
+
+/*
+Create new custom client of DaData. By example, this option should be used to Google AppEngine:
+    ctx := appengine.NewContext(request)
+    appEngineClient := urlfetch.Client(ctx)
+    daData:= NewDaDataCustomClient(apiKey, secretKey, client)
+*/
+func NewDaDataCustomClient(apiKey, secretKey string, httpClient *http.Client) *DaData {
 	return &DaData{
 		ApiKey:     apiKey,
-		SecretKey:  sercretKey,
-		httpClient: &http.Client{},
+		SecretKey:  secretKey,
+		httpClient: httpClient,
 	}
 }
 


### PR DESCRIPTION
Fixed for Google AppEngine

Original AppEngine error message is "Post https://dadata.ru/api/v2/clean/address: http.DefaultTransport and http.DefaultClient are not available in App Engine. See https://cloud.google.com/appengine/docs/go/urlfetch/"

added "func NewDaDataCustomClient(...)"
changed "func NewDaData(...)" to use "func NewDaDataCustomClient(...)"

use it for Google AppEngine and etc:

    ctx := appengine.NewContext(request)
    appEngineClient := urlfetch.Client(ctx)
    daData:= NewDaDataCustomClient(apiKey, secretKey, client)

Russian:
Платформа Google AppEngine не позволяет выполнять http-запросы с использование простого http-клиента. Вместо него Google AppEngine требует использовать возможности пакета "appengine/urlfetch". 

К счастью, библиотека (пакет) DaData устанавливает http-клиент при инициализации и затем использует его. Но, к сожалению, во время инициализации нет возможности указать произвольный клиент инициализации.

Добавлена функция "func NewDaDataCustomClient(...)", которая отличается от простой функции инициализации "func NewDaData(...)" только тем, что имеет дополнительный параметр - в котором можно передать ссылку на любой http-клиент (хоть тот, что используется в языке Go по умолчанию, хоть тот, что требуется использовать на платформе Google AppEngine, хоть любой другой). 

Инициализировать DaData при использовании с Google AppEngine можно, например, так:

    ctx := appengine.NewContext(request)
    appEngineClient := urlfetch.Client(ctx)
    daData:= NewDaDataCustomClient(apiKey, secretKey, client)

Здесь "urlfetch" это пакет "appengine/urlfetch".

Функция "func NewDaData(...)" исправлена - теперь она вызывает "func NewDaDataCustomClient(...)", указывая в качестве http-клиента тот, что и использовался в ней ранее.

Под Google AppEngine протестировано. Напрямую без Google AppEngine исправление не проверялось.
