### PR TITLE
Корректное закрытие HTTP соединений

### DIFF
--- a/dadata.go
+++ b/dadata.go
@@ -61,12 +61,15 @@ func (daData *DaData) sendRequest(lastUrlPart string, source interface{}, result
 	request.Header.Add("X-Secret", daData.SecretKey)
 	request.Header.Add("Content-Type", "application/json")
 	request.Header.Add("Accept", "application/json")
+	request.Header.Set("Connection", "close")
 
 	response, httpErr := daData.httpClient.Do(request)
 	if nil != httpErr {
 		fmt.Printf("httpErr: %v", httpErr)
 		return httpErr
 	}
+
+	defer response.Body.Close()
 
 	if http.StatusOK != response.StatusCode {
 		return fmt.Errorf("Request error %v", response.Status)


### PR DESCRIPTION
Исправление, корректно закрывающее HTTP соединение к серверу dadata.

Без него можно легко получить ошибку httpErr: socket: too many open files при обработке больших объемов данных.